### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: idoris
+  annotations:
+    github.com/project-slug: maximiliani/idoris
+spec:
+  type: other
+  lifecycle: unknown
+  owner: core

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,9 +2,59 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: idoris
+  title: idoris
+  description: Integrated Data Type and Operations Registry with Inheritance System
+  tags: ["FAIR-DO", "DTR", "Java", "Spring"]
   annotations:
     github.com/project-slug: maximiliani/idoris
+    github.com/user-login: maximiliani
+    backstage.io/source-location: url:https://github.com/maximiliani/idoris
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/managed-by-origin-location: url:http://github.com/maximiliani/idoris/blob/master/catalog-info.yaml
 spec:
-  type: other
-  lifecycle: unknown
+  type: service
+  lifecycle: experimental
+  owner: maximiliani
+  system: idoris
+
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: idoris-rest-api
+spec:
+  type: openapi
+  lifecycle: experimental
+  owner: maximiliani
+  system: idoris
+  definition: |
+    openapi: "3.0.0"
+      info:
+        version: 0.0.1
+        title: IDORIS API
+        license:
+          name: Apache 2.0
+      servers:
+        - url: http://localhost:8095/api
+      paths:
+
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: idoris
+spec:
+  owner: maximiliani
+  type: service
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-domain
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: fairdo
+  description: Essential FAIR-DO architecture components
+spec:
   owner: core
+  type: product-area


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Scaffolded Backstage App software catalog](http://localhost:3000).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).